### PR TITLE
fix: escape vendor prefixed props

### DIFF
--- a/src/functions/transform.js
+++ b/src/functions/transform.js
@@ -169,6 +169,16 @@ export const transform = c => {
     let prop = both[0];
     let value = both[1];
 
+    // Convert prop from CSS to JS
+    if (prop) {
+      if (prop.startsWith("-")) {
+        prop = `"${prop}"`;
+      } else if (prop.includes("-")) {
+        prop = prop.replace(/-([a-z])/g, g => g[1].toUpperCase());
+      }
+    }
+
+    // Convert value from CSS to JS
     if (value) {
       if (value.includes("px")) {
         value = parseInt(value.split("px")[0]);
@@ -176,14 +186,6 @@ export const transform = c => {
         value = `${value.split('"').join("'")}`;
       } else {
         value = `${value.trim()}`;
-      }
-
-      if (prop.startsWith("-")) {
-        prop = `${prop}`;
-      }
-
-      if (!prop.startsWith("-") && prop.includes("-")) {
-        prop = prop.replace(/-([a-z])/g, g => g[1].toUpperCase());
       }
     }
 


### PR DESCRIPTION
When using a prop that is [vendor prefixed](https://developer.mozilla.org/en-US/docs/Glossary/Vendor_Prefix), for example `-webkit-someprop`, the transformer produced invalid JS synax.

Current behavior:
![image](https://user-images.githubusercontent.com/12124298/77204391-ed0e7900-6af2-11ea-8fe0-cb16bd98c15f.png)
The JS object key starts with `-`, which is invalid syntax.


New behaviour:
![image](https://user-images.githubusercontent.com/12124298/77204363-df58f380-6af2-11ea-981b-90d21548f357.png)
The JS object key the same as before but wrapped in quotes, which is valid syntax.