### PR TITLE
Mode for CSS => React props

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,6 @@
 import React, { useState, useRef, useEffect } from "react";
 import { transform as transformCss2Obj } from "./functions/transformCss2Obj";
+import { transform as transformCss2Jsx } from "./functions/transformCss2Jsx";
 import { transform as transformObj2Jsx } from "./functions/transformObj2Jsx";
 import useClipboard from "react-use-clipboard";
 import Code from "./code";
@@ -17,6 +18,10 @@ const modes = {
   css2obj: {
     name: "CSS => JS object",
     transformer: transformCss2Obj
+  },
+  css2jsx: {
+    name: "CSS => React props",
+    transformer: transformCss2Jsx
   },
   obj2jsx: {
     name: "JS object => React props",

--- a/src/functions/transformCss2Jsx.js
+++ b/src/functions/transformCss2Jsx.js
@@ -1,0 +1,16 @@
+import { transform as css2obj } from "./transformCss2Obj";
+import { transform as obj2jsx } from "./transformObj2Jsx";
+
+export function transform(css) {
+  const obj = css2obj(css);
+  return obj2jsx(obj);
+}
+
+if (typeof window === "undefined") {
+  exports.handler = function({ body }, context, callback) {
+    callback(null, {
+      statusCode: 200,
+      body: transform(body)
+    });
+  };
+}


### PR DESCRIPTION
This PR simply combines the two existing modes (CSS => obj and obj => JSX) into a new mode (CSS => JSX). Yay for transitivity!

![image](https://user-images.githubusercontent.com/12124298/77253175-f1ed3d00-6c58-11ea-841a-704bc61b45bb.png)
