### PR TITLE
React props => JS object

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,19 @@
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 
-Transform CSS to JS Objects and JS Objects to React Props
+Transform between CSS, JS Objects and React props.
 
 https://css2js.dotenv.dev/
+
+Currently, we can do this:
+
+```
+    ✅    ✅
+    =>    =>
+CSS    JS    JSX
+    <=    <=
+    ❌    ✅
+```
 
 
 

--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,7 @@
 import React, { useState, useRef, useEffect } from "react";
 import { transform as transformCss2Obj } from "./functions/transformCss2Obj";
 import { transform as transformObj2Jsx } from "./functions/transformObj2Jsx";
+import { transform as transformJsx2Obj } from "./functions/transformJsx2Obj";
 import useClipboard from "react-use-clipboard";
 import Code from "./code";
 import Logo from "./logo";
@@ -21,6 +22,10 @@ const modes = {
   obj2jsx: {
     name: "JS object => React props",
     transformer: transformObj2Jsx
+  },
+  jsx2obj: {
+    name: "React props => JS object",
+    transformer: transformJsx2Obj
   }
 };
 

--- a/src/functions/__tests__/__snapshots__/transformJsx2Obj.test.js.snap
+++ b/src/functions/__tests__/__snapshots__/transformJsx2Obj.test.js.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`transformJsx2Obj transforms props on a single line 1`] = `
+"{
+  display: \\"block\\",
+  fontSize: 16,
+}"
+`;
+
+exports[`transformJsx2Obj transforms props on multiple lines 1`] = `
+"{
+  display: \\"block\\",
+  fontSize: 16,
+  margin: { xs: 4, sm: 8 },
+  padding: [2, 3],
+  background: \\"#1e2f5d\\",
+  color: \\"#a4cff4\\",
+  fontFamily: \\"'Inter', sans-serif\\",
+  fontWeight: \\"bold\\",
+}"
+`;

--- a/src/functions/__tests__/transformJsx2Obj.test.js
+++ b/src/functions/__tests__/transformJsx2Obj.test.js
@@ -26,6 +26,11 @@ describe("transformJsx2Obj", () => {
     expect(transform(input)).toContain(`someProp: undefined`);
   });
 
+  test("transforms a rule without a value to `true`", () => {
+    const input = `someProp`;
+    expect(transform(input)).toContain(`someProp: true`);
+  });
+
   test("transforms props on a single line", () => {
     expect(
       transform(`

--- a/src/functions/__tests__/transformJsx2Obj.test.js
+++ b/src/functions/__tests__/transformJsx2Obj.test.js
@@ -16,6 +16,11 @@ describe("transformJsx2Obj", () => {
     expect(transform(input)).toContain(`someProp: { key: "value" }`);
   });
 
+  test("transforms a rule with a complex object value", () => {
+    const input = `someProp={{ x: { y: z } }}`;
+    expect(transform(input)).toContain(`someProp: { x: { y: z } }`);
+  });
+
   test("transforms a rule with an arbitrary expression value", () => {
     const input = `someProp={someExpression}`;
     expect(transform(input)).toContain(`someProp: someExpression`);

--- a/src/functions/__tests__/transformJsx2Obj.test.js
+++ b/src/functions/__tests__/transformJsx2Obj.test.js
@@ -37,11 +37,7 @@ describe("transformJsx2Obj", () => {
   });
 
   test("transforms props on a single line", () => {
-    expect(
-      transform(`
-        display="block" fontSize={16}
-      `)
-    ).toMatchSnapshot();
+    expect(transform(`display="block" fontSize={16}`)).toMatchSnapshot();
   });
 
   test("transforms props on multiple lines", () => {

--- a/src/functions/__tests__/transformJsx2Obj.test.js
+++ b/src/functions/__tests__/transformJsx2Obj.test.js
@@ -1,0 +1,50 @@
+import { transform } from "../transformJsx2Obj";
+
+describe("transformJsx2Obj", () => {
+  test("transforms a rule with a string value", () => {
+    const input = `someProp="someValue"`;
+    expect(transform(input)).toContain(`someProp: "someValue"`);
+  });
+
+  test("transforms a rule with a number value", () => {
+    const input = `someProp={42}`;
+    expect(transform(input)).toContain(`someProp: 42`);
+  });
+
+  test("transforms a rule with an object value", () => {
+    const input = `someProp={{ key: "value" }}`;
+    expect(transform(input)).toContain(`someProp: { key: "value" }`);
+  });
+
+  test("transforms a rule with an arbitrary expression value", () => {
+    const input = `someProp={someExpression}`;
+    expect(transform(input)).toContain(`someProp: someExpression`);
+  });
+
+  test("transforms an empty expression to `undefined`", () => {
+    const input = `someProp={}`;
+    expect(transform(input)).toContain(`someProp: undefined`);
+  });
+
+  test("transforms props on a single line", () => {
+    expect(
+      transform(`
+        display="block" fontSize={16}
+      `)
+    ).toMatchSnapshot();
+  });
+
+  test("transforms props on multiple lines", () => {
+    expect(
+      transform(
+        `display="block"
+        fontSize={16}
+        margin={{ xs: 4, sm: 8 }}
+        padding={[2, 3]}
+        background="#1e2f5d"
+        color="#a4cff4"
+        fontFamily="'Inter', sans-serif" fontWeight="bold"`
+      )
+    ).toMatchSnapshot();
+  });
+});

--- a/src/functions/__tests__/transformObj2Jsx.test.js
+++ b/src/functions/__tests__/transformObj2Jsx.test.js
@@ -52,4 +52,14 @@ describe("transformObj2Jsx", () => {
     const input = `someProp: 'some"Value'`;
     expect(transform(input)).toBe(`someProp={'some"Value'}`);
   });
+
+  test("transforms a rule with an escaped char in its value", () => {
+    const input = `someProp: "some\\tValue"`;
+    expect(transform(input)).toBe(`someProp={"some\\tValue"}`);
+  });
+
+  test("transforms an invalid string value to `{undefined}`", () => {
+    const input = `someProp: "imInvalid`;
+    expect(transform(input)).toBe(`someProp={undefined}`);
+  });
 });

--- a/src/functions/__tests__/transformObj2Jsx.test.js
+++ b/src/functions/__tests__/transformObj2Jsx.test.js
@@ -21,6 +21,11 @@ describe("transformObj2Jsx", () => {
     expect(transform(input)).toBe(`someProp={someExpression}`);
   });
 
+  test("transforms a rule with value `true` to a prop with no value", () => {
+    const input = `someProp: true`;
+    expect(transform(input)).toBe(`someProp`);
+  });
+
   test("transforms a simple object", () => {
     expect(
       transform(`{

--- a/src/functions/transformJsx2Obj.js
+++ b/src/functions/transformJsx2Obj.js
@@ -1,3 +1,8 @@
+/**
+ * Transforms React props to a JS object.
+ * @param {string} jsx props in JSX format as a single string
+ * @returns {string} formatted JS object as a string
+ */
 export function transform(jsx) {
   // Parse JSX into a JS object
   const rules = {};

--- a/src/functions/transformJsx2Obj.js
+++ b/src/functions/transformJsx2Obj.js
@@ -1,15 +1,21 @@
 export function transform(jsx) {
   // Parse JSX into a JS object
   const rules = {};
-  const matchIterator = jsx.matchAll(/(\w+)=(".*?"|{.*?}+)/g);
+  const matchIterator = jsx.matchAll(/(\w+)=?(".*?"|{.*?}+)?/g);
   for (const match of matchIterator) {
-    if (match.length < 3) {
-      // Something has gone wrong, skip this one
+    let property = match[1];
+    let value = match[2];
+
+    if (typeof property !== "string" || property === "") {
+      // Skip this one
       continue;
     }
 
-    let property = match[1];
-    let value = match[2];
+    // A property without a value is interpreted as the boolean `true`
+    // (how it works in JSX)
+    if (value === undefined) {
+      value = "true";
+    }
 
     // If value is an expression, remove the curly braces
     if (value.startsWith("{")) {

--- a/src/functions/transformJsx2Obj.js
+++ b/src/functions/transformJsx2Obj.js
@@ -1,0 +1,33 @@
+export function transform(jsx) {
+  // Parse JSX into a JS object
+  const rules = {};
+  const matchIterator = jsx.matchAll(/(\w+)=(".*?"|{.*?}+)/g);
+  for (const match of matchIterator) {
+    if (match.length < 3) {
+      // Something has gone wrong, skip this one
+      continue;
+    }
+
+    let property = match[1];
+    let value = match[2];
+
+    // If value is an expression, remove the curly braces
+    if (value.startsWith("{")) {
+      value = value.slice(1, -1);
+    }
+
+    // Show undefined instead of nothing
+    if (value === "") {
+      value = "undefined";
+    }
+
+    rules[property] = value;
+  }
+
+  // Format JS object
+  return [
+    "{",
+    ...Object.keys(rules).map(property => `  ${property}: ${rules[property]},`),
+    "}"
+  ].join("\n");
+}

--- a/src/functions/transformJsx2Obj.js
+++ b/src/functions/transformJsx2Obj.js
@@ -1,13 +1,20 @@
 export function transform(jsx) {
   // Parse JSX into a JS object
   const rules = {};
-  const matchIterator = jsx.matchAll(/(\w+)=?(".*?"|{.*?}+)?/g);
+  const matchIterator = jsx.matchAll(/(\w+)=?(".*?"|{.*?}[\s}]*)?/g);
   for (const match of matchIterator) {
     let property = match[1];
     let value = match[2];
 
-    if (typeof property !== "string" || property === "") {
-      // Skip this one
+    if (property) {
+      property = property.trim();
+    }
+    if (value) {
+      value = value.trim();
+    }
+
+    if (property === "") {
+      // Skip this rule
       continue;
     }
 

--- a/src/functions/transformObj2Jsx.js
+++ b/src/functions/transformObj2Jsx.js
@@ -61,12 +61,18 @@ export const transform = code => {
     }
 
     if (value.startsWith(`"`) || value.startsWith(`'`)) {
+      // Value is probably a plain string, but need to do some more checks
       let first = value.charAt(0);
       let middle = value.slice(1, -1); // all except first and last char
       let last = value.charAt(value.length - 1);
 
-      if (middle.includes(`"`)) {
-        // If the string value contains a double quote, we need to wrap it in
+      if (last !== first) {
+        // It's a string but not correctly wrapped in quotes
+        return `${key}={undefined}`;
+      }
+
+      if (middle.includes("\\") || middle.includes(`"`)) {
+        // If the string value contains escaped characters, we need to wrap it in
         // curly brackets (escaping does not work in JSX prop values)
         value = `{${value}}`;
       } else {
@@ -80,7 +86,7 @@ export const transform = code => {
         value = `${first}${middle}${last}`;
       }
     } else {
-      // If value is not a plain string, wrap it in curly braces
+      // Value is not a plain string, wrap it in curly braces
       value = `{${value}}`;
     }
 

--- a/src/functions/transformObj2Jsx.js
+++ b/src/functions/transformObj2Jsx.js
@@ -54,6 +54,12 @@ export const transform = code => {
   const propStrings = Object.keys(rules).map(key => {
     let value = rules[key];
 
+    // The value `true` is special, because it can be transformed to a prop
+    // with no value in JSX
+    if (value === "true") {
+      return key;
+    }
+
     if (value.startsWith(`"`) || value.startsWith(`'`)) {
       let first = value.charAt(0);
       let middle = value.slice(1, -1); // all except first and last char


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/12124298/77257814-e90b6400-6c76-11ea-99cc-1a351bb5f031.png)

It seems to work pretty well, though it's not perfect. In particular it likes to see things that aren't props at all as a "prop with no value", which is transformed to a value of `true`. But that should only happen when the input are not valid props.

Also I'd like to make it possible to paste an entire React component as input, and take only the props from that. But in order to get all those edge cases I think we'll need a different approach. Otherwise the RegEx's are going to get out of control :smile: 