### PR TITLE
Integration tests for homepage

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+EXTEND_ESLINT=true

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@reach/router": "^1.3.3",
-    "@testing-library/jest-dom": "^4.2.4",
+    "@testing-library/jest-dom": "^5.2.0",
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
     "netlify-lambda": "^1.6.3",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@testing-library/jest-dom": "^5.2.0",
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
+    "eslint-plugin-testing-library": "^2.2.3",
     "netlify-lambda": "^1.6.3",
     "normalize.css": "^8.0.1",
     "prettier": "^1.19.1",
@@ -26,7 +27,13 @@
     "eject": "react-scripts eject"
   },
   "eslintConfig": {
-    "extends": "react-app"
+    "extends": [
+      "react-app",
+      "plugin:testing-library/react"
+    ],
+    "plugins": [
+      "testing-library"
+    ]
   },
   "browserslist": {
     "production": [

--- a/src/__tests__/home.test.js
+++ b/src/__tests__/home.test.js
@@ -39,16 +39,16 @@ describe("<Home />", () => {
   });
 
   test("displays some output on load", async () => {
-    const { getByTitle } = render(<Home />);
-    const outputBox = getByTitle("output");
+    const { getByTestId } = render(<Home />);
+    const outputBox = getByTestId("output");
 
     await wait(() => expect(outputBox.textContent).not.toBe(""));
   });
 
   test("transforms the input when it is changed", async () => {
-    const { getByRole, getByTitle, findByText } = render(<Home />);
+    const { getByRole, getByTestId, findByText } = render(<Home />);
     const inputBox = getByRole("textbox");
-    const outputBox = getByTitle("output");
+    const outputBox = getByTestId("output");
     const testInput = "my test input";
     const expectedOutput = defaultTransformer.transform(testInput);
 

--- a/src/__tests__/home.test.js
+++ b/src/__tests__/home.test.js
@@ -1,0 +1,50 @@
+import React from "react";
+import { render, wait } from "@testing-library/react";
+import transformersMock from "../transformers";
+import Home from "../home";
+
+// The transform functions are already unit tested, so replace them with stubs
+jest.mock("../transformers", () => {
+  // TODO: use Transformer type (or will Jest KNOWWW that it should be same TYPE??? :O)
+  return {
+    css2js: {
+      id: 0,
+      name: "CSS => JS object",
+      transform: jest.fn(x => x),
+      from: "css",
+      to: "js"
+    },
+    js2css: {
+      id: 1,
+      name: "JS object => CSS",
+      transform: jest.fn(x => x),
+      from: "js",
+      to: "css"
+    }
+  };
+});
+
+describe("<Home />", () => {
+  test("renders without exploding", () => {
+    render(<Home />);
+  });
+
+  test("has an element that lets the user enter text", () => {
+    const { getByRole } = render(<Home />);
+    expect(getByRole("textbox")).toBeInTheDocument();
+  });
+
+  test("calls the default transform function on load", () => {
+    render(<Home />);
+    const transformFunction = transformersMock.css2js.transform;
+    wait(() => expect(transformFunction.mock.toHaveBeenCalled(1)));
+  });
+
+  // TODO: do we really want to assert on the number of function calls?
+  // Why not set the input (either by firing an event or setting the value on
+  // the dom element) and wait for the output to be changed?
+
+  // TODO: can we somehow abstract away from the "default transformer"?
+  // Maybe just use the "first" transformer as default? Though that's less explicit
+  // and makes it harder to understand how the default transformer is set.
+});

--- a/src/__tests__/home.test.js
+++ b/src/__tests__/home.test.js
@@ -1,16 +1,17 @@
 import React from "react";
-import { render, wait } from "@testing-library/react";
-import transformersMock from "../transformers";
+import { render, wait, fireEvent } from "@testing-library/react";
+import mockedTransformers from "../transformers";
 import Home from "../home";
 
 // The transform functions are already unit tested, so replace them with stubs
 jest.mock("../transformers", () => {
   // TODO: use Transformer type (or will Jest KNOWWW that it should be same TYPE??? :O)
+  // mabye `typeof realTransformers`??
   return {
     css2js: {
       id: 0,
       name: "CSS => JS object",
-      transform: jest.fn(x => x),
+      transform: jest.fn(x => x.toUpperCase()),
       from: "css",
       to: "js"
     },
@@ -24,6 +25,9 @@ jest.mock("../transformers", () => {
   };
 });
 
+// This should be the same as the default transformer state in home.js
+const defaultTransformer = mockedTransformers.css2js;
+
 describe("<Home />", () => {
   test("renders without exploding", () => {
     render(<Home />);
@@ -34,15 +38,25 @@ describe("<Home />", () => {
     expect(getByRole("textbox")).toBeInTheDocument();
   });
 
-  test("calls the default transform function on load", () => {
-    render(<Home />);
-    const transformFunction = transformersMock.css2js.transform;
-    wait(() => expect(transformFunction.mock.toHaveBeenCalled(1)));
+  test("displays some output on load", async () => {
+    const { getByTitle } = render(<Home />);
+    const outputBox = getByTitle("output");
+
+    await wait(() => expect(outputBox.textContent).not.toBe(""));
   });
 
-  // TODO: do we really want to assert on the number of function calls?
-  // Why not set the input (either by firing an event or setting the value on
-  // the dom element) and wait for the output to be changed?
+  test("transforms the input when it is changed", async () => {
+    const { getByRole, getByTitle, findByText } = render(<Home />);
+    const inputBox = getByRole("textbox");
+    const outputBox = getByTitle("output");
+    const testInput = "my test input";
+    const expectedOutput = defaultTransformer.transform(testInput);
+
+    fireEvent.change(inputBox, { target: { value: testInput } });
+
+    expect(await findByText(testInput)).toBeInTheDocument();
+    await wait(() => expect(outputBox.textContent).toBe(expectedOutput));
+  });
 
   // TODO: can we somehow abstract away from the "default transformer"?
   // Maybe just use the "first" transformer as default? Though that's less explicit

--- a/src/__tests__/home.test.js
+++ b/src/__tests__/home.test.js
@@ -26,6 +26,9 @@ jest.mock("../transformers", () => {
 });
 
 // This should be the same as the default transformer state in home.js
+// TODO: can we somehow abstract away from the "default transformer"?
+// Maybe just use the "first" transformer as default? Though that's less explicit
+// and makes it harder to understand how the default transformer is set.
 const defaultTransformer = mockedTransformers.css2js;
 
 describe("<Home />", () => {
@@ -38,11 +41,9 @@ describe("<Home />", () => {
     expect(getByRole("textbox")).toBeInTheDocument();
   });
 
-  test("displays some output on load", async () => {
-    const { getByTestId } = render(<Home />);
-    const outputBox = getByTestId("output");
-
-    await wait(() => expect(outputBox.textContent).not.toBe(""));
+  test("displays some example input on load", async () => {
+    const { getByRole } = render(<Home />);
+    expect(getByRole("textbox").textContent).not.toBe("");
   });
 
   test("transforms the input when it is changed", async () => {
@@ -57,8 +58,4 @@ describe("<Home />", () => {
     expect(await findByText(testInput)).toBeInTheDocument();
     await wait(() => expect(outputBox.textContent).toBe(expectedOutput));
   });
-
-  // TODO: can we somehow abstract away from the "default transformer"?
-  // Maybe just use the "first" transformer as default? Though that's less explicit
-  // and makes it harder to understand how the default transformer is set.
 });

--- a/src/components/code.js
+++ b/src/components/code.js
@@ -5,7 +5,7 @@ import nightOwl from "prism-react-renderer/themes/nightOwl";
 const Code = ({ code, language }) => (
   <Highlight {...defaultProps} theme={nightOwl} code={code} language={language}>
     {({ className, style, tokens, getLineProps, getTokenProps }) => (
-      <pre className={className} style={style}>
+      <pre className={className} style={style} title="output">
         {tokens.map((line, i) => (
           <div {...getLineProps({ line, key: i })}>
             {line.map((token, key) => (

--- a/src/components/code.js
+++ b/src/components/code.js
@@ -5,7 +5,7 @@ import nightOwl from "prism-react-renderer/themes/nightOwl";
 const Code = ({ code, language }) => (
   <Highlight {...defaultProps} theme={nightOwl} code={code} language={language}>
     {({ className, style, tokens, getLineProps, getTokenProps }) => (
-      <pre className={className} style={style} title="output">
+      <pre className={className} style={style} data-testid="output">
         {tokens.map((line, i) => (
           <div {...getLineProps({ line, key: i })}>
             {line.map((token, key) => (

--- a/src/home.js
+++ b/src/home.js
@@ -83,7 +83,6 @@ function Home() {
             focusable="false"
             role="presentation"
             aria-hidden="true"
-            class="css-12c4avn"
           >
             <path
               fill="currentColor"

--- a/src/home.js
+++ b/src/home.js
@@ -7,7 +7,7 @@ import Header from "./components/header";
 import { exampleCSS, exampleJS, exampleJSX } from "./utils/exampleCode";
 
 function Home() {
-  const [input, setInput] = useState(exampleCSS);
+  const [input, setInput] = useState("");
   const [transformer, setTransformer] = useState(transformers.css2js);
   const [transformed, setTransformed] = useState("");
   const textarea = useRef(null);

--- a/src/pages/__tests__/home.test.tsx
+++ b/src/pages/__tests__/home.test.tsx
@@ -1,12 +1,10 @@
 import React from "react";
 import { render, wait, fireEvent } from "@testing-library/react";
-import mockedTransformers from "../transformers";
+import mockedTransformers from "../../transformers";
 import Home from "../home";
 
 // The transform functions are already unit tested, so replace them with stubs
-jest.mock("../transformers", () => {
-  // TODO: use Transformer type (or will Jest KNOWWW that it should be same TYPE??? :O)
-  // mabye `typeof realTransformers`??
+jest.mock("../../transformers", (): typeof mockedTransformers => {
   return {
     css2js: {
       id: 0,

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom";

--- a/yarn.lock
+++ b/yarn.lock
@@ -4443,6 +4443,11 @@ eslint-plugin-react@7.18.0:
     prop-types "^15.7.2"
     resolve "^1.14.2"
 
+eslint-plugin-testing-library@^2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-testing-library/-/eslint-plugin-testing-library-2.2.3.tgz#de42d0c07e10578a2edb880c973758e948e7b47d"
+  integrity sha512-pqMTWjBxYv+TnuU3ZzbdUJ0s5p5jSInlk6ly+YnTBNCDy2aLYpnNqeEinYzj1nH8Cthij62ajqzgODg6J25QNA==
+
 eslint-scope@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.3.tgz#ca03833310f6889a3264781aa82e63eb9cfe7848"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1155,10 +1155,17 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
-"@babel/runtime@^7.5.1", "@babel/runtime@^7.7.4", "@babel/runtime@^7.8.4":
+"@babel/runtime@^7.7.4", "@babel/runtime@^7.8.4":
   version "7.8.7"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.8.7.tgz#8fefce9802db54881ba59f90bb28719b4996324d"
   integrity sha512-+AATMUFppJDw6aiR5NVPHqIQBlV/Pj8wY/EZH+lmvRdUo9xBaz/rF3alAwFJQavvKfeOlPE7oaaDHVbcySbCsg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
+"@babel/runtime@^7.9.2":
+  version "7.9.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.9.2.tgz#d90df0583a3a252f09aaa619665367bae518db06"
+  integrity sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -1482,6 +1489,16 @@
     "@types/yargs" "^15.0.0"
     chalk "^3.0.0"
 
+"@jest/types@^25.2.0":
+  version "25.2.0"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-25.2.0.tgz#0659866d9b31843a737b601b950a690e576a415a"
+  integrity sha512-RLWBAON8LEjzD60Cn0XFmvMNTuV+scKlufIUApnG7VF7oA2jCEk5J0uzEchx6xuOwhrHohQM28K4CmEjgtDEwg==
+  dependencies:
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^1.1.1"
+    "@types/yargs" "^15.0.0"
+    chalk "^3.0.0"
+
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"
@@ -1647,19 +1664,19 @@
     pretty-format "^25.1.0"
     wait-for-expect "^3.0.2"
 
-"@testing-library/jest-dom@^4.2.4":
-  version "4.2.4"
-  resolved "https://registry.yarnpkg.com/@testing-library/jest-dom/-/jest-dom-4.2.4.tgz#00dfa0cbdd837d9a3c2a7f3f0a248ea6e7b89742"
-  integrity sha512-j31Bn0rQo12fhCWOUWy9fl7wtqkp7In/YP2p5ZFyRuiiB9Qs3g+hS4gAmDWONbAHcRmVooNJ5eOHQDCOmUFXHg==
+"@testing-library/jest-dom@^5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/jest-dom/-/jest-dom-5.2.0.tgz#9c3886dd88b5c7c9e25bfaa05cf16d17480c565b"
+  integrity sha512-ugXtbRmH5wJhx9FzkV5X5hw1RDZPEm9LR08eRdLqaGWWmUpu4KdazJdPwGN0C0szNtZUc/ox2RIQUv9QZeTXbg==
   dependencies:
-    "@babel/runtime" "^7.5.1"
-    chalk "^2.4.1"
-    css "^2.2.3"
+    "@babel/runtime" "^7.9.2"
+    "@types/testing-library__jest-dom" "^5.0.2"
+    chalk "^3.0.0"
+    css "^2.2.4"
     css.escape "^1.5.1"
-    jest-diff "^24.0.0"
-    jest-matcher-utils "^24.0.0"
-    lodash "^4.17.11"
-    pretty-format "^24.0.0"
+    jest-diff "^25.1.0"
+    jest-matcher-utils "^25.1.0"
+    lodash "^4.17.15"
     redent "^3.0.0"
 
 "@testing-library/react@^9.3.2":
@@ -1753,6 +1770,14 @@
     "@types/istanbul-lib-coverage" "*"
     "@types/istanbul-lib-report" "*"
 
+"@types/jest@*":
+  version "25.1.4"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-25.1.4.tgz#9e9f1e59dda86d3fd56afce71d1ea1b331f6f760"
+  integrity sha512-QDDY2uNAhCV7TMCITrxz+MRk1EizcsevzfeS6LykIlq2V1E5oO4wXG8V2ZEd9w7Snxeeagk46YbMgZ8ESHx3sw==
+  dependencies:
+    jest-diff "^25.1.0"
+    pretty-format "^25.1.0"
+
 "@types/json-schema@^7.0.3":
   version "7.0.4"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.4.tgz#38fd73ddfd9b55abb1e1b2ed578cb55bd7b7d339"
@@ -1809,6 +1834,13 @@
   integrity sha512-cgqnEjxKk31tQt29j4baSWaZPNjQf3bHalj2gcHQTpW5SuHRal76gOpF0vypeEo6o+sS5inOvvNdzLY0B3FB2A==
   dependencies:
     pretty-format "^24.3.0"
+
+"@types/testing-library__jest-dom@^5.0.2":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.0.2.tgz#89b782e0f187fe1e80d6375133da74182ba02065"
+  integrity sha512-dZP+/WHndgCSmdaImITy0KhjGAa9c0hlGGkzefbtrPFpnGEPZECDA0zyvfSp8RKhHECJJSKHFExjOwzo0rHyIA==
+  dependencies:
+    "@types/jest" "*"
 
 "@types/testing-library__react@^9.1.2":
   version "9.1.3"
@@ -3674,7 +3706,7 @@ css.escape@^1.5.1:
   resolved "https://registry.yarnpkg.com/css.escape/-/css.escape-1.5.1.tgz#42e27d4fa04ae32f931a4b4d4191fa9cddee97cb"
   integrity sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=
 
-css@^2.0.0, css@^2.2.3:
+css@^2.0.0, css@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/css/-/css-2.2.4.tgz#c646755c73971f2bba6a601e2cf2fd71b1298929"
   integrity sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==
@@ -3968,6 +4000,11 @@ diff-sequences@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-24.9.0.tgz#5715d6244e2aa65f48bba0bc972db0b0b11e95b5"
   integrity sha512-Dj6Wk3tWyTE+Fo1rW8v0Xhwk80um6yFYKbuAxc9c3EZxIHFDYwbi34Uk42u1CdnIiVorvt4RmlSDjIPyzGC2ew==
+
+diff-sequences@^25.2.0:
+  version "25.2.0"
+  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-25.2.0.tgz#180bd89ff45c490b175de6dbb1d346db7b998a94"
+  integrity sha512-qTbUrz80F9q6rmEZjUoK2/SQTwgaOvnE5WjKlemKuod1iuB4WlSjY5ft2VUXacsqD9pXrWmERMPLi+j9RldxGg==
 
 diffie-hellman@^5.0.0:
   version "5.0.3"
@@ -6139,7 +6176,7 @@ jest-config@^24.9.0:
     pretty-format "^24.9.0"
     realpath-native "^1.1.0"
 
-jest-diff@^24.0.0, jest-diff@^24.9.0:
+jest-diff@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-24.9.0.tgz#931b7d0d5778a1baf7452cb816e325e3724055da"
   integrity sha512-qMfrTs8AdJE2iqrTp0hzh7kTd2PQWrsFyj9tORoKmu32xjPjeE4NyjVRDz8ybYwqS2ik8N4hsIpiVTyFeo2lBQ==
@@ -6148,6 +6185,16 @@ jest-diff@^24.0.0, jest-diff@^24.9.0:
     diff-sequences "^24.9.0"
     jest-get-type "^24.9.0"
     pretty-format "^24.9.0"
+
+jest-diff@^25.1.0, jest-diff@^25.2.0:
+  version "25.2.0"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-25.2.0.tgz#d9d0138494b9c34acbb63508836cf11b6736f5dc"
+  integrity sha512-4qNJ9ELNECVeApQ62d8HWGyWzLOXwO81awCoKkHA34Kz8jyP8fQE1lQiZDmLmZRnzoFfIZAAo84u2DlBQ8SrsQ==
+  dependencies:
+    chalk "^3.0.0"
+    diff-sequences "^25.2.0"
+    jest-get-type "^25.1.0"
+    pretty-format "^25.2.0"
 
 jest-docblock@^24.3.0:
   version "24.9.0"
@@ -6207,6 +6254,11 @@ jest-get-type@^24.9.0:
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-24.9.0.tgz#1684a0c8a50f2e4901b6644ae861f579eed2ef0e"
   integrity sha512-lUseMzAley4LhIcpSP9Jf+fTrQ4a1yHQwLNeeVa2cEmbCGeoZAtYPOIv8JaxLD/sUpKxetKGP+gsHl8f8TSj8Q==
 
+jest-get-type@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-25.1.0.tgz#1cfe5fc34f148dc3a8a3b7275f6b9ce9e2e8a876"
+  integrity sha512-yWkBnT+5tMr8ANB6V+OjmrIJufHtCAqI5ic2H40v+tRqxDmE0PGnIiTyvRWFOMtmVHYpwRqyazDbTnhpjsGvLw==
+
 jest-haste-map@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-24.9.0.tgz#b38a5d64274934e21fa417ae9a9fbeb77ceaac7d"
@@ -6256,7 +6308,7 @@ jest-leak-detector@^24.9.0:
     jest-get-type "^24.9.0"
     pretty-format "^24.9.0"
 
-jest-matcher-utils@^24.0.0, jest-matcher-utils@^24.9.0:
+jest-matcher-utils@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-24.9.0.tgz#f5b3661d5e628dffe6dd65251dfdae0e87c3a073"
   integrity sha512-OZz2IXsu6eaiMAwe67c1T+5tUAtQyQx27/EMEkbFAGiw52tB9em+uGbzpcgYVpA8wl0hlxKPZxrly4CXU/GjHA==
@@ -6265,6 +6317,16 @@ jest-matcher-utils@^24.0.0, jest-matcher-utils@^24.9.0:
     jest-diff "^24.9.0"
     jest-get-type "^24.9.0"
     pretty-format "^24.9.0"
+
+jest-matcher-utils@^25.1.0:
+  version "25.2.0"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-25.2.0.tgz#d61f725b14f46e9eaf1b335324ecdf0b28845124"
+  integrity sha512-8E2ggFOJ5h1DPUqAswp78rasfqPap2Iryt06wtwrYXNJrbX0R5pi76eYdduSpPXn1atIbK+uxeJNmqYXLpddog==
+  dependencies:
+    chalk "^3.0.0"
+    jest-diff "^25.2.0"
+    jest-get-type "^25.1.0"
+    pretty-format "^25.2.0"
 
 jest-message-util@^24.9.0:
   version "24.9.0"
@@ -8732,7 +8794,7 @@ pretty-error@^2.1.1:
     renderkid "^2.0.1"
     utila "~0.4"
 
-pretty-format@^24.0.0, pretty-format@^24.3.0, pretty-format@^24.9.0:
+pretty-format@^24.3.0, pretty-format@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-24.9.0.tgz#12fac31b37019a4eea3c11aa9a959eb7628aa7c9"
   integrity sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==
@@ -8748,6 +8810,16 @@ pretty-format@^25.1.0:
   integrity sha512-46zLRSGLd02Rp+Lhad9zzuNZ+swunitn8zIpfD2B4OPCRLXbM87RJT2aBLBWYOznNUML/2l/ReMyWNC80PJBUQ==
   dependencies:
     "@jest/types" "^25.1.0"
+    ansi-regex "^5.0.0"
+    ansi-styles "^4.0.0"
+    react-is "^16.12.0"
+
+pretty-format@^25.2.0:
+  version "25.2.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-25.2.0.tgz#645003fb5da71a0ded46c90007dff0e03857de7d"
+  integrity sha512-BzmuH01b/lm0nl3M7Lcnku9Cv2UNMk9FgIrAiSuIus2QrjzV7Lf2DW+88SgEQUXQNkYWGtBV1289AuF6yMCtCQ==
+  dependencies:
+    "@jest/types" "^25.2.0"
     ansi-regex "^5.0.0"
     ansi-styles "^4.0.0"
     react-is "^16.12.0"


### PR DESCRIPTION
This PR adds tests for the homepage component `pages/home.tsx`. It also adds the ESLint plugin for testing-library, which helps to avoid pitfalls.