### PR TITLE
Fix: bad input transform

### DIFF
--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -24,8 +24,7 @@ const Home: React.FC<RouteComponentProps> = () => {
   // TODO: do we need useLayoutEffect? need to make sure input is transformed
   // before re-render
   useEffect(() => {
-    // TODO: can we compare transformer directly?
-    if (prevTransformer && transformer.id !== prevTransformer.id) {
+    if (prevTransformer && transformer !== prevTransformer) {
       const intermediateTransformer = findTransformerByFromTo(
         prevTransformer.from,
         transformer.from

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -14,12 +14,11 @@ import Header from "../components/header";
 
 const Home: React.FC<RouteComponentProps> = () => {
   const [input, setInput] = useState(exampleCSS);
-  const [transformed, setTransformed] = useState("");
-
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
-
+  const [output, setOutput] = useState("");
   const [transformer, setTransformer] = useState(transformers.css2js);
   const prevTransformer = usePrevious(transformer);
+
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   // Update input when transformer is changed
   useEffect(() => {
@@ -38,16 +37,16 @@ const Home: React.FC<RouteComponentProps> = () => {
   // Update output when input or transformer is changed
   useEffect(() => {
     try {
-      const newTransformed = transformer.transform(input);
-      setTransformed(newTransformed);
+      const newOutput = transformer.transform(input);
+      setOutput(newOutput);
     } catch (e) {
-      setTransformed(
+      setOutput(
         `Something went wrong while transforming the code: ${e.message}`
       );
     }
   }, [input, transformer]);
 
-  const [isCopied, setCopied] = useClipboard(transformed, {
+  const [isCopied, setCopied] = useClipboard(output, {
     successDuration: 1000
   });
 
@@ -124,7 +123,7 @@ const Home: React.FC<RouteComponentProps> = () => {
         />
 
         <Code
-          code={transformed}
+          code={output}
           language={transformer.to === "jsx" ? "js" : transformer.to}
         />
       </section>

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -21,6 +21,7 @@ const Home: React.FC<RouteComponentProps> = () => {
   const [transformer, setTransformer] = useState(transformers.css2js);
   const prevTransformer = usePrevious(transformer);
 
+  // Update input when transformer is changed
   useEffect(() => {
     if (prevTransformer && transformer !== prevTransformer) {
       const intermediateTransformer = findTransformerByFromTo(
@@ -34,7 +35,7 @@ const Home: React.FC<RouteComponentProps> = () => {
     }
   }, [input, transformer, prevTransformer]);
 
-  // Synchronize input and transformed ouput
+  // Update output when input or transformer is changed
   useEffect(() => {
     try {
       const newTransformed = transformer.transform(input);

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -21,8 +21,6 @@ const Home: React.FC<RouteComponentProps> = () => {
   const [transformer, setTransformer] = useState(transformers.css2js);
   const prevTransformer = usePrevious(transformer);
 
-  // TODO: do we need useLayoutEffect? need to make sure input is transformed
-  // before re-render
   useEffect(() => {
     if (prevTransformer && transformer !== prevTransformer) {
       const intermediateTransformer = findTransformerByFromTo(

--- a/src/utils/exampleCode.js
+++ b/src/utils/exampleCode.js
@@ -5,3 +5,20 @@ color: #a4cff4;
 font-family: "Inter", sans-serif;
 font-weight: bold;
 `;
+
+export const exampleJS = `{
+  display: "block",
+  fontSize: 16,
+  background: "#1e2f5d",
+  color: "#a4cff4",
+  fontFamily: "'Inter', sans-serif",
+  fontWeight: "bold"
+}`;
+
+export const exampleJSX = `display="block"
+fontSize={16}
+background="#1e2f5d"
+color="#a4cff4"
+fontFamily="'Inter', sans-serif"
+fontWeight="bold"
+`;

--- a/src/utils/usePrevious.ts
+++ b/src/utils/usePrevious.ts
@@ -1,0 +1,9 @@
+import { useRef, useEffect } from "react";
+
+export function usePrevious<T>(value: T) {
+  const ref = useRef<T>();
+  useEffect(() => {
+    ref.current = value;
+  });
+  return ref.current;
+}


### PR DESCRIPTION
Fixes #21.

Previously, I was using `useReducer` pretty much only because it makes it possible to access the previous state. I was using that previous state to produce a side effect (transform the input).

Now, I'm using `useEffect` to produce the side effect, while using the `usePrevious` hook to access the previous state. This is a bit cleaner IMO, and it seems to be the [recommended way to get previous state)[https://reactjs.org/docs/hooks-faq.html#how-to-get-the-previous-props-or-state].

I considered using `useLayoutEffect` instead of `useEffect`, because it seems like this effect should run before re-rendering UI. For example, we want to avoid the situation where the transformer is changed, but the input has not yet been transformed. In practice, this is not a huge issue since our current transform functions are not very expensive. But in testing, I found no difference between `useLayoutEffect` and `useEffect`. Both caused the app to be unresponsive until the effect was done. So maybe that's not exactly a problem `useLayoutEffect` can solve.

I'm still not entirely sure what caused the bug in the first place, but I'll write some details in the issue. I also wasn't able to write a test for it, since I don't understand the root cause. Unfortunately, if the bug was to appear again, we would only catch it with manual testing or maybe end-to-end testing.